### PR TITLE
compile stack with TLS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,14 @@ RUN stack setup
 # in parallel. However, this can cause OOM issues as the linking step
 # in GHC can be expensive. If the build fails, try specifying the
 # # '-j1' flag to force the build to run sequentially.
-RUN stack install -j1
+RUN stack install
 
 FROM debian:buster
 
 ENV LANG C.UTF-8
 
 RUN apt-get update -qq && \
-  apt-get install -qq -y libpcre3 libgmp10 libssl-dev --no-install-recommends && \
+  apt-get install -qq -y libpcre3 libgmp10 libssl-dev ca-certificates --no-install-recommends && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN stack setup
 # NOTE:`stack build` will use as many cores as are available to build
 # in parallel. However, this can cause OOM issues as the linking step
 # in GHC can be expensive. If the build fails, try specifying the
-# # '-j1' flag to force the build to run sequentially.
+# '-j1' flag to force the build to run sequentially.
 RUN stack install
 
 FROM debian:buster
@@ -26,7 +26,7 @@ FROM debian:buster
 ENV LANG C.UTF-8
 
 RUN apt-get update -qq && \
-  apt-get install -qq -y libpcre3 libgmp10 libssl-dev ca-certificates --no-install-recommends && \
+  apt-get install -qq -y libpcre3 libgmp10 libssl-dev --no-install-recommends && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM haskell:8 AS builder
 
 RUN apt-get update -qq && \
-  apt-get install -qq -y libpcre3 libpcre3-dev build-essential --fix-missing --no-install-recommends && \
+  apt-get install -qq -y libssl-dev libpcre3 libpcre3-dev build-essential --fix-missing --no-install-recommends && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -15,19 +15,18 @@ ENV LANG=C.UTF-8
 
 RUN stack setup
 
-
 # NOTE:`stack build` will use as many cores as are available to build
 # in parallel. However, this can cause OOM issues as the linking step
 # in GHC can be expensive. If the build fails, try specifying the
-# '-j1' flag to force the build to run sequentially.
-RUN stack install
+# # '-j1' flag to force the build to run sequentially.
+RUN stack install -j1
 
 FROM debian:buster
 
 ENV LANG C.UTF-8
 
 RUN apt-get update -qq && \
-  apt-get install -qq -y libpcre3 libgmp10 --no-install-recommends && \
+  apt-get install -qq -y libpcre3 libgmp10 libssl-dev --no-install-recommends && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,8 @@ packages:
 
 extra-deps: []
 
-flags: {}
+flags:
+  snap-server:
+    openssl: True
 
 extra-package-dbs: []


### PR DESCRIPTION
- Add `libssl-dev` to dockerfile to compile `stack` with TLS suppport

This makes it possible to run duckling with TLS. 