### PR TITLE
Add dist-upgrade to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ FROM debian:buster
 ENV LANG C.UTF-8
 
 RUN apt-get update -qq && \
+  apt-get dist-upgrade -qq -y --no-install-recommends && \
   apt-get install -qq -y libpcre3 libgmp10 libssl-dev --no-install-recommends && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Fix for the liblz4-1 package is available but not part of upstream buster image yet.
Adding dist-upgrade to make sure we install all available updates regardless of upstream image state.

[CVE-2021-3520](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3520)
